### PR TITLE
feat(python3): remove non-3 compatible dependency

### DIFF
--- a/graphene_tornado/tornado_executor.py
+++ b/graphene_tornado/tornado_executor.py
@@ -1,8 +1,8 @@
-from compiler.future import is_future
-
 from promise import Promise
 from tornado.gen import convert_yielded, multi_future
 from tornado.ioloop import IOLoop
+from tornado.concurrent import is_future
+
 
 # https://gist.github.com/isi-gach/daef0b34ec5af6f026af52d593131c64
 class TornadoExecutor(object):


### PR DESCRIPTION
tornado+graphql tastes best when served with python3.  This PR removes the single instance of `compiler` dependency deprecated in python2.6 and not included in python3.  It is replaced with `tornado.concurrent.is_future` which does the hardwork to handle both python2 and python3 using asyncio and concurrent.futures.

remove non-python3 compatible `compiler` dependency and replace `compiler.future.is_future` with
`tornado.concurrent.is_future`. Rest of project is compatible with python3.7.